### PR TITLE
[Doc] cifar10 doc example

### DIFF
--- a/docs/source/datasets/cifar10.rst
+++ b/docs/source/datasets/cifar10.rst
@@ -1,0 +1,90 @@
+CIFAR-10
+========
+
+.. raw:: html
+
+   <p style="display: flex; gap: 10px;">
+   <img src="https://img.shields.io/badge/Task-Image%20Classification-blue" alt="Task: Image Classification">
+   <img src="https://img.shields.io/badge/Classes-10-green" alt="Classes: 10">
+   <img src="https://img.shields.io/badge/Size-32x32-orange" alt="Image Size: 32x32">
+   </p>
+
+Overview
+--------
+
+The CIFAR-10 dataset is a widely-used image classification benchmark for single-label classification consisting of 60,000 32×32 RGB color images across 10 balanced classes (airplane, automobile, bird, cat, deer, dog, frog, horse, ship, and truck), with 6,000 images per class.
+
+- **Train**: 50,000 images (5,000 per class)
+- **Test**: 10,000 images (1,000 per class)
+
+Data Structure
+--------------
+
+When accessing an example using ``dataset['train'][i]``, you will receive a dictionary with the following keys:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Key
+     - Type
+     - Description
+   * - ``image``
+     - PIL Image / numpy array
+     - 32×32×3 RGB image
+   * - ``label``
+     - int
+     - Class label (0-9)
+
+Usage Example
+-------------
+
+**Basic Usage**
+
+.. code-block:: python
+
+    from stable_datasets import load_dataset
+
+    # Load the dataset
+    dataset = load_dataset('cifar10')
+    
+    # Access a single example
+    example = dataset['train'][0]
+    image = example['image']  # 32x32x3 RGB image
+    label = example['label']  # integer from 0-9
+    
+    # Iterate over the dataset
+    for item in dataset['train']:
+        image, label = item['image'], item['label']
+        # Your processing here
+
+Related Datasets
+----------------
+
+- **CIFAR-100**: Extended version with 100 classes, sharing the same image dimensions
+- **CIFAR-10-C**: Corrupted version of CIFAR-10 for testing robustness (available in stable-datasets as ``cifar10_c``)
+- **CIFAR-100-C**: Corrupted version of CIFAR-100 (available in stable-datasets as ``cifar100_c``)
+
+References
+----------
+
+- Official website: https://www.cs.toronto.edu/~kriz/cifar.html
+- License: MIT License
+
+Citation
+--------
+
+.. code-block:: bibtex
+
+    @Techreport{krizhevsky2009learning,
+    author = {Krizhevsky, Alex and Hinton, Geoffrey},
+    address = {Toronto, Ontario},
+    institution = {University of Toronto},
+    number = {0},
+    publisher = {Technical report, University of Toronto},
+    title = {Learning multiple layers of features from tiny images},
+    year = {2009},
+    title_with_no_special_chars = {Learning multiple layers of features from tiny images},
+    url = {https://www.cs.toronto.edu/~kriz/learning-features-2009-TR.pdf}
+    }
+

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -1,0 +1,47 @@
+Datasets
+========
+
+This section provides detailed documentation for all datasets available in stable-datasets.
+
+Overview
+--------
+
+stable-datasets provides easy access to a wide variety of datasets for machine learning research, with a focus on stability and reproducibility. Each dataset page includes:
+
+- **Example Samples**: Visual examples or data snippets from the dataset
+- **Dataset Details**: Number of classes, target types, and data specifications
+- **Data Structure**: Keys and data types returned when accessing the dataset
+- **Usage Examples**: Code snippets showing how to load and use the dataset
+- **Related Datasets**: Links to similar or derived datasets
+- **Citation**: The original paper to cite when using the dataset
+
+Getting Started
+---------------
+
+All datasets can be loaded using the same consistent API:
+
+.. code-block:: python
+
+    from stable_datasets import load_dataset
+
+    # Load a dataset
+    dataset = load_dataset('dataset_name')
+    
+    # Access splits
+    train_data = dataset['train']
+    test_data = dataset['test']
+    
+    # Access individual examples
+    example = train_data[0]
+
+Available Datasets
+------------------
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Image Classification Datasets
+
+   cifar10
+
+.. note::
+   Documentation is being added progressively, as datasets are ready for usage. Please only use datasets found in the documentation.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ stable-datasets
 
 .. rst-class:: lead
 
-----
+   A comprehensive collection of stable, reproducible datasets for machine learning research.
 
 Welcome to the docs for stable-datasets.
 We recommend using ``python>=3.10``, and installation using ``uv``:
@@ -36,12 +36,22 @@ If you would like to start testing or contribute to ``stable-datasets`` then ple
     cd stable-datasets
     pip install -e .
 
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   :hidden:
+
+   datasets/index
+   introduction/quickstart
+   introduction/showcase
+   introduction/contributing
+
 Citation
 --------
 
 If you find this library useful in your research, please consider citing us:
 
-.. code-block::
+.. code-block:: bibtex
 
     @misc{stable-datasets,
       author = {},


### PR DESCRIPTION
# What does this PR do?

Adds doc example for CIFAR10. All that is missing is example images, which will be added once I create a future script that will auto-make the figure for a generic dataset.

## Who can review?

@lucas-maes or @RandallBalestriero 
