### PR TITLE
Expose processed cache dir (and download dir) on BaseDatasetBuilder outputs

### DIFF
--- a/stable_datasets/tests/test_base.py
+++ b/stable_datasets/tests/test_base.py
@@ -95,6 +95,9 @@ def test_base_builder_processed_cache_dir_is_used(tmp_path):
     for cache_entry in ds.cache_files:
         assert cache_entry["filename"].startswith(str(tmp_path))
 
+    # stable-datasets also exposes the processed cache location as a convenience attribute.
+    assert getattr(ds, "_stable_datasets_processed_cache_dir") == tmp_path
+
 
 def test_base_builder_passes_download_dir_to_bulk_download(tmp_path, monkeypatch):
     import stable_datasets.utils as utils

--- a/stable_datasets/utils.py
+++ b/stable_datasets/utils.py
@@ -206,6 +206,7 @@ class BaseDatasetBuilder(datasets.GeneratorBasedBuilder):
         # Processed cache (Arrow)
         if processed_cache_dir is None:
             processed_cache_dir = str(_default_processed_cache_dir())
+        instance._processed_cache_dir = Path(processed_cache_dir)
 
         # Raw downloads
         if download_dir is None:
@@ -233,6 +234,17 @@ class BaseDatasetBuilder(datasets.GeneratorBasedBuilder):
             result = instance.as_dataset()
         else:
             result = instance.as_dataset(split=split)
+
+        # Expose cache locations on the returned dataset object for convenience.
+        # Note: DatasetDict may not allow attribute assignment; ignore if not supported.
+        try:
+            setattr(result, "_stable_datasets_processed_cache_dir", instance._processed_cache_dir)
+        except Exception:
+            pass
+        try:
+            setattr(result, "_stable_datasets_download_dir", instance._raw_download_dir)
+        except Exception:
+            pass
         return result
 
 


### PR DESCRIPTION
# What does this PR do?

Expose processed cache dir (and download dir) on BaseDatasetBuilder outputs.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/rbalestr-lab/stable-datasets/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/rbalestr-lab/stable-datasets/tree/main/docs)
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @
If you know how to use git blame, that is the easiest way, otherwise, please tag @lucas-maes or @RandallBalestriero -->

<!-- Some tips on docstring writing https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation -->
